### PR TITLE
Add command flag and config validation for --sslmode

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -118,12 +118,12 @@ func (t *TimescaleDBHandler) Validate(event *corev2.Event) error {
 	if len(t.Config.Table) == 0 {
 		return errors.New("missing Table")
 	}
-	if !event.HasMetrics() {
-		return errors.New("event does not contain metrics")
-	}
 	var sslmodes = []string{"disable", "require", "verify-ca", "verify-full"}
 	if indexOf(t.Config.SslMode, sslmodes) < 0 {
 		return fmt.Errorf("unsupported sslmode \"%s\"", t.Config.SslMode)
+	}
+	if !event.HasMetrics() {
+		return errors.New("event does not contain metrics")
 	}
 	return nil
 }

--- a/handler.go
+++ b/handler.go
@@ -123,7 +123,7 @@ func (t *TimescaleDBHandler) Validate(event *corev2.Event) error {
 	}
 	var sslmodes = []string{"disable", "require", "verify-ca", "verify-full"}
 	if indexOf(t.Config.SslMode, sslmodes) < 0 {
-		return errors.New(fmt.Sprintf("unsupported sslmode \"%s\"", t.Config.SslMode))
+		return fmt.Errorf("unsupported sslmode \"%s\"", t.Config.SslMode)
 	}
 	return nil
 }

--- a/handler.go
+++ b/handler.go
@@ -7,7 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
-
+	"net/url"
+	
 	_ "github.com/lib/pq"
 	"github.com/sensu-community/sensu-plugin-sdk/sensu"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -26,8 +27,9 @@ type TimescaleDBHandlerConfig struct {
 	// DSN is a data source name. It is either a URL or a postgres connection
 	// string. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 	// for more information.
-	DSN   string
-	Table string
+	DSN     string
+	Table   string
+	SslMode string
 }
 
 // Run runs the timescaledb handler
@@ -76,6 +78,24 @@ func (t *TimescaleDBHandler) ProcessEvent(event *corev2.Event) error {
 
 // Setup sets up the timescaledb handler
 func (t *TimescaleDBHandler) Setup() error {
+	// Set connection parameter defaults
+	// Reference: https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
+	params := url.Values{}
+	params.Set("sslmode", t.Config.SslMode)
+
+	// Parse the Data Source Name (DSN) & add missing default parameters
+	dsn,err := url.Parse(t.Config.DSN)
+	if err != nil {
+		return err
+	} 
+	q := dsn.Query()
+	for k := range q {
+		params.Set(k,q[k][0])
+	}
+	dsn.RawQuery = params.Encode()
+	t.Config.DSN = dsn.String()
+	
+	// Connect to TimescaleDB (Postgres database)
 	db, err := sql.Open("postgres", t.Config.DSN)
 	if err != nil {
 		return err
@@ -101,6 +121,10 @@ func (t *TimescaleDBHandler) Validate(event *corev2.Event) error {
 	if !event.HasMetrics() {
 		return errors.New("event does not contain metrics")
 	}
+	var sslmodes = []string{"disable","require","verify-ca","verify-full"}
+	if indexOf(t.Config.SslMode,sslmodes) < 0 {
+		return errors.New(fmt.Sprintf("unsupported sslmode \"%s\"", t.Config.SslMode))
+	}
 	return nil
 }
 
@@ -114,4 +138,13 @@ func convertInt64ToTime(t int64) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return time.Unix(t, 0), nil
+}
+
+func indexOf(k string, s []string) (int) {
+	for i,v := range s {
+		if k == v {
+			return i
+		}
+	}
+	return -1
 }

--- a/handler.go
+++ b/handler.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
-	"net/url"
-	
+
 	_ "github.com/lib/pq"
 	"github.com/sensu-community/sensu-plugin-sdk/sensu"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -84,17 +84,17 @@ func (t *TimescaleDBHandler) Setup() error {
 	params.Set("sslmode", t.Config.SslMode)
 
 	// Parse the Data Source Name (DSN) & add missing default parameters
-	dsn,err := url.Parse(t.Config.DSN)
+	dsn, err := url.Parse(t.Config.DSN)
 	if err != nil {
 		return err
-	} 
+	}
 	q := dsn.Query()
 	for k := range q {
-		params.Set(k,q[k][0])
+		params.Set(k, q[k][0])
 	}
 	dsn.RawQuery = params.Encode()
 	t.Config.DSN = dsn.String()
-	
+
 	// Connect to TimescaleDB (Postgres database)
 	db, err := sql.Open("postgres", t.Config.DSN)
 	if err != nil {
@@ -121,8 +121,8 @@ func (t *TimescaleDBHandler) Validate(event *corev2.Event) error {
 	if !event.HasMetrics() {
 		return errors.New("event does not contain metrics")
 	}
-	var sslmodes = []string{"disable","require","verify-ca","verify-full"}
-	if indexOf(t.Config.SslMode,sslmodes) < 0 {
+	var sslmodes = []string{"disable", "require", "verify-ca", "verify-full"}
+	if indexOf(t.Config.SslMode, sslmodes) < 0 {
 		return errors.New(fmt.Sprintf("unsupported sslmode \"%s\"", t.Config.SslMode))
 	}
 	return nil
@@ -140,8 +140,8 @@ func convertInt64ToTime(t int64) (time.Time, error) {
 	return time.Unix(t, 0), nil
 }
 
-func indexOf(k string, s []string) (int) {
-	for i,v := range s {
+func indexOf(k string, s []string) int {
+	for i, v := range s {
 		if k == v {
 			return i
 		}

--- a/handler_test.go
+++ b/handler_test.go
@@ -84,11 +84,24 @@ func TestTimescaleDBHandler_Validate(t *testing.T) {
 			errMatch: "missing Table",
 		},
 		{
+			name: "fail when invalid sslmode specified",
+			fields: fields{
+				Config: TimescaleDBHandlerConfig{
+					DSN:     "postgresql://foohost/bardb",
+					Table:   "metrics",
+					SslMode: "test",
+				},
+			},
+			wantErr:  true,
+			errMatch: "unsupported sslmode \"test\"",
+		},
+		{
 			name: "fail when event has no metrics",
 			fields: fields{
 				Config: TimescaleDBHandlerConfig{
-					DSN:   "postgresql://foohost/bardb",
-					Table: "metrics",
+					DSN:     "postgresql://foohost/bardb",
+					Table:   "metrics",
+					SslMode: "disable",
 				},
 			},
 			args: args{

--- a/handler_test.go
+++ b/handler_test.go
@@ -101,8 +101,9 @@ func TestTimescaleDBHandler_Validate(t *testing.T) {
 			name: "pass when required config and args are met",
 			fields: fields{
 				Config: TimescaleDBHandlerConfig{
-					DSN:   "postgresql://foohost/bardb",
-					Table: "metrics",
+					DSN:     "postgresql://foohost/bardb",
+					Table:   "metrics",
+					SslMode: "disable",
 				},
 			},
 			args: args{

--- a/main.go
+++ b/main.go
@@ -39,8 +39,8 @@ func main() {
 			Default:   "require",
 			Usage:     "the sslmode to use to connect to the database",
 			Value:     &handler.Config.SslMode,
-	},
-}
+		},
+	}
 
 	goHandler := sensu.NewGoHandler(&handler.PluginConfig, configOptions, handler.Validate, handler.Run)
 	goHandler.Execute()

--- a/main.go
+++ b/main.go
@@ -31,7 +31,16 @@ func main() {
 			Usage:     "the PostgreSQL table to store metrics in",
 			Value:     &handler.Config.Table,
 		},
-	}
+		{
+			Path:      "sslmode",
+			Env:       "TIMESCALEDB_SSLMODE",
+			Argument:  "sslmode",
+			Shorthand: "s",
+			Default:   "require",
+			Usage:     "the sslmode to use to connect to the database",
+			Value:     &handler.Config.SslMode,
+	},
+}
 
 	goHandler := sensu.NewGoHandler(&handler.PluginConfig, configOptions, handler.Validate, handler.Run)
 	goHandler.Execute()


### PR DESCRIPTION
Add support for `--sslmode` with config validation. 

There are other connection parameters we may wish to add support for (e.g. `sslcert`, `sslkey`, `sslrootcert`), so I tried implementing this in a way where it will be easy to add the additional flags; i.e. parsing the DSN url and injecting missing parameters. 

This probably needs some tests, but it unblocks something I'm working on as-is... 

Closes #4 